### PR TITLE
Extra metrics

### DIFF
--- a/collector/exporter.go
+++ b/collector/exporter.go
@@ -221,6 +221,114 @@ func New(cfg config.Config, st domain.Store) *Exporter {
 				},
 			},
 			{
+				enabled: cfg.ExportPools,
+				gaugeVec: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+					Namespace: Name,
+					Subsystem: SubsystemPools,
+					Name:      "active_server",
+					Help:      "Server connections that linked to client.",
+				}, []string{"database", "user", "pool_mode"}),
+				resolve: func(res *storeResult) (items []gaugeVecValueItem) {
+					for _, pool := range res.pools {
+						items = append(items, gaugeVecValueItem{
+							labels: []string{pool.Database, pool.User, pool.PoolMode},
+							count:  float64(pool.ServerActive),
+						})
+					}
+					return items
+				},
+			},
+			{
+				enabled: cfg.ExportPools,
+				gaugeVec: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+					Namespace: Name,
+					Subsystem: SubsystemPools,
+					Name:      "idle_server",
+					Help:      "Server connections that unused and immediately usable for client queries.",
+				}, []string{"database", "user", "pool_mode"}),
+				resolve: func(res *storeResult) (items []gaugeVecValueItem) {
+					for _, pool := range res.pools {
+						items = append(items, gaugeVecValueItem{
+							labels: []string{pool.Database, pool.User, pool.PoolMode},
+							count:  float64(pool.ServerIdle),
+						})
+					}
+					return items
+				},
+			},
+			{
+				enabled: cfg.ExportPools,
+				gaugeVec: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+					Namespace: Name,
+					Subsystem: SubsystemPools,
+					Name:      "used_server",
+					Help:      "Server connections that have been idle more than server_check_delay, so they needs server_check_query to run on it before it can be used.",
+				}, []string{"database", "user", "pool_mode"}),
+				resolve: func(res *storeResult) (items []gaugeVecValueItem) {
+					for _, pool := range res.pools {
+						items = append(items, gaugeVecValueItem{
+							labels: []string{pool.Database, pool.User, pool.PoolMode},
+							count:  float64(pool.ServerUsed),
+						})
+					}
+					return items
+				},
+			},
+			{
+				enabled: cfg.ExportPools,
+				gaugeVec: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+					Namespace: Name,
+					Subsystem: SubsystemPools,
+					Name:      "tested_server",
+					Help:      "Server connections that are currently running either server_reset_query or server_check_query.",
+				}, []string{"database", "user", "pool_mode"}),
+				resolve: func(res *storeResult) (items []gaugeVecValueItem) {
+					for _, pool := range res.pools {
+						items = append(items, gaugeVecValueItem{
+							labels: []string{pool.Database, pool.User, pool.PoolMode},
+							count:  float64(pool.ServerTested),
+						})
+					}
+					return items
+				},
+			},
+			{
+				enabled: cfg.ExportPools,
+				gaugeVec: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+					Namespace: Name,
+					Subsystem: SubsystemPools,
+					Name:      "login_server",
+					Help:      "Server connections currently in logging in process.",
+				}, []string{"database", "user", "pool_mode"}),
+				resolve: func(res *storeResult) (items []gaugeVecValueItem) {
+					for _, pool := range res.pools {
+						items = append(items, gaugeVecValueItem{
+							labels: []string{pool.Database, pool.User, pool.PoolMode},
+							count:  float64(pool.ServerLogin),
+						})
+					}
+					return items
+				},
+			},
+			{
+				enabled: cfg.ExportPools,
+				gaugeVec: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+					Namespace: Name,
+					Subsystem: SubsystemPools,
+					Name:      "max_wait",
+					Help:      "How long the first (oldest) client in queue has waited, in seconds. If this starts increasing, then the current pool of servers does not handle requests quick enough. Reason may be either overloaded server or just too small of a pool_size setting.",
+				}, []string{"database", "user", "pool_mode"}),
+				resolve: func(res *storeResult) (items []gaugeVecValueItem) {
+					for _, pool := range res.pools {
+						items = append(items, gaugeVecValueItem{
+							labels: []string{pool.Database, pool.User, pool.PoolMode},
+							count:  float64(pool.MaxWait),
+						})
+					}
+					return items
+				},
+			},
+			{
 				enabled: cfg.ExportDatabases,
 				gaugeVec: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 					Namespace: Name,

--- a/collector/exporter.go
+++ b/collector/exporter.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/jbub/pgbouncer_exporter/config"
 	"github.com/jbub/pgbouncer_exporter/domain"
-
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/log"
 )
@@ -126,6 +125,60 @@ func New(cfg config.Config, st domain.Store) *Exporter {
 						items = append(items, gaugeVecValueItem{
 							labels: []string{stat.Database},
 							count:  float64(stat.TotalQueryTime),
+						})
+					}
+					return items
+				},
+			},
+			{
+				enabled: cfg.ExportStats,
+				gaugeVec: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+					Namespace: Name,
+					Subsystem: SubsystemStats,
+					Name:      "total_xact_time",
+					Help:      "Total number of microseconds spent by pgbouncer when connected to PostgreSQL in a transaction, either idle in transaction or executing queries.",
+				}, []string{"database"}),
+				resolve: func(res *storeResult) (items []gaugeVecValueItem) {
+					for _, stat := range res.stats {
+						items = append(items, gaugeVecValueItem{
+							labels: []string{stat.Database},
+							count:  float64(stat.TotalXactTime),
+						})
+					}
+					return items
+				},
+			},
+			{
+				enabled: cfg.ExportStats,
+				gaugeVec: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+					Namespace: Name,
+					Subsystem: SubsystemStats,
+					Name:      "total_query_count",
+					Help:      "Total number of SQL queries pooled by pgbouncer.",
+				}, []string{"database"}),
+				resolve: func(res *storeResult) (items []gaugeVecValueItem) {
+					for _, stat := range res.stats {
+						items = append(items, gaugeVecValueItem{
+							labels: []string{stat.Database},
+							count:  float64(stat.TotalQueryCount),
+						})
+					}
+					return items
+				},
+			},
+			{
+				enabled: cfg.ExportStats,
+				gaugeVec: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+					Namespace: Name,
+					Subsystem: SubsystemStats,
+					Name:      "total_xact_count",
+					Help:      "Total number of SQL transactions pooled by pgbouncer.",
+				}, []string{"database"}),
+				resolve: func(res *storeResult) (items []gaugeVecValueItem) {
+					for _, stat := range res.stats {
+						items = append(items, gaugeVecValueItem{
+							labels: []string{stat.Database},
+							count:  float64(stat.TotalXactCount),
 						})
 					}
 					return items


### PR DESCRIPTION
Thanks for your work on this exporter. We've been using it for a while now.

I've exposed extra metrics that we find useful.

From stats:
  -  `total_xact_time`
  -  `total_xact_count`
  -  `total_query_count`

From pools (different names than pgbouncer's to match your client naming style):
  - `active_server` -> `sv_active`
  - `idle_server` -> `sv_idle`
  - `used_server` -> `sv_used`
  - `tested_server` -> `sv_tested`
  - `login_server` -> `sv_login`
  - `max_wait` -> `maxwait`

As I said above, I've tried to use a similar naming structure as the existing ones but please let me know if you would like me to change any.

