### PR TITLE
Add client and server metrics to export

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Pgbouncer exporter 
+# Pgbouncer exporter
 [![Build Status](https://cloud.drone.io/api/badges/jbub/pgbouncer_exporter/status.svg)][drone]
 [![Docker Pulls](https://img.shields.io/docker/pulls/jbub/pgbouncer_exporter.svg?maxAge=604800)][hub]
 [![Go Report Card](https://goreportcard.com/badge/github.com/jbub/pgbouncer_exporter)][goreportcard]
@@ -10,8 +10,8 @@ Prometheus exporter for Pgbouncer metrics.
 Metrics are by default exposed on http server running on port `9127` under the `/metrics` path.
 
 ```bash
-docker run \ 
-  --detach \ 
+docker run \
+  --detach \
   --env "DATABASE_URL=postgres://user:password@pgbouncer:6432/pgbouncer?sslmode=disable" \
   --publish "9127:9127" \
   --name "pgbouncer_exporter" \
@@ -23,12 +23,14 @@ docker run \
 All of the collectors are enabled by default, you can control that using environment variables by settings
 it to `true` or `false`.
 
-| Name          | Description                             | Env var          | Default |
-|---------------|-----------------------------------------|------------------|---------|
-| stats         | Per database requests stats.            | EXPORT_STATS     | Enabled |
-| pools         | Per (database, user) connection stats.  | EXPORT_POOLS     | Enabled |
-| databases     | List of configured databases.           | EXPORT_DATABASES | Enabled |
-| lists         | List of internal pgbouncer information. | EXPORT_LISTS     | Enabled |
+| Name      | Description                             | Env var          | Default |
+|-----------|-----------------------------------------|------------------|---------|
+| stats     | Per database requests stats.            | EXPORT_STATS     | Enabled |
+| pools     | Per (database, user) connection stats.  | EXPORT_POOLS     | Enabled |
+| databases | List of configured databases.           | EXPORT_DATABASES | Enabled |
+| lists     | List of internal pgbouncer information. | EXPORT_LISTS     | Enabled |
+| servers   | Per application name/db stats.          | EXPORT_SERVERS   | Enabled |
+| clients   | Per application name/db stats.          | EXPORT_CLIENTS   | Enabled |
 
 [drone]: https://cloud.drone.io/jbub/pgbouncer_exporter
 [hub]: https://hub.docker.com/r/jbub/pgbouncer_exporter

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,8 @@ func LoadFromCLI(ctx *cli.Context) Config {
 		ExportPools:     ctx.Bool("export-pools"),
 		ExportDatabases: ctx.Bool("export-databases"),
 		ExportLists:     ctx.Bool("export-lists"),
+		ExportServers:   ctx.Bool("export-servers"),
+		ExportClients:   ctx.Bool("export-clients"),
 	}
 }
 
@@ -30,4 +32,6 @@ type Config struct {
 	ExportPools     bool
 	ExportDatabases bool
 	ExportLists     bool
+	ExportServers   bool
+	ExportClients   bool
 }

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -64,6 +64,20 @@ type List struct {
 	Items int64
 }
 
+// Server represents server row.
+type Server struct {
+	User     string
+	Database string
+	State    string
+}
+
+// Client represents client row.
+type Client struct {
+	User     string
+	Database string
+	State    string
+}
+
 // Store defines interface for accessing pgbouncer stats.
 type Store interface {
 	// GetStats returns stats.
@@ -77,6 +91,12 @@ type Store interface {
 
 	// GetLists returns lists.
 	GetLists(ctx context.Context) ([]List, error)
+
+	// GetServers returns servers.
+	GetServers(ctx context.Context) ([]Server, error)
+
+	// GetClients returns clients.
+	GetClients(ctx context.Context) ([]Client, error)
 
 	// Check checks the health of the store.
 	Check(ctx context.Context) error

--- a/internal/server/http_test.go
+++ b/internal/server/http_test.go
@@ -25,6 +25,8 @@ var (
 		exportDatabases bool
 		exportStats     bool
 		exportLists     bool
+		exportServers   bool
+		exportClients   bool
 		metrics         []string
 	}{
 		{
@@ -61,6 +63,27 @@ var (
 			metrics: []string{
 				buildInfoMetric,
 				metricName(collector.SubsystemLists, "items"),
+			},
+		},
+		{
+			name:          "servers",
+			exportServers: true,
+			metrics: []string{
+				buildInfoMetric,
+				metricName(collector.SubsystemServers, "active"),
+				metricName(collector.SubsystemServers, "used"),
+				metricName(collector.SubsystemServers, "idle"),
+			},
+		},
+		{
+			name:          "clients",
+			exportClients: true,
+			metrics: []string{
+				buildInfoMetric,
+				metricName(collector.SubsystemClients, "active"),
+				metricName(collector.SubsystemClients, "used"),
+				metricName(collector.SubsystemClients, "waiting"),
+				metricName(collector.SubsystemClients, "idle"),
 			},
 		},
 	}
@@ -124,6 +147,45 @@ func newTestingStore() *store.MockStore {
 			Items: 68,
 		},
 	}
+	st.Servers = []domain.Server{
+		{
+			User:     "xx1",
+			Database: "xx",
+			State:    "active",
+		},
+		{
+			User:     "xx2",
+			Database: "xx",
+			State:    "used",
+		},
+		{
+			User:     "yy1",
+			Database: "yy",
+			State:    "idle",
+		},
+	}
+	st.Clients = []domain.Client{
+		{
+			User:     "xx1",
+			Database: "xx",
+			State:    "active",
+		},
+		{
+			User:     "xx2",
+			Database: "xx",
+			State:    "used",
+		},
+		{
+			User:     "yy1",
+			Database: "yy",
+			State:    "waiting",
+		},
+		{
+			User:     "yy2",
+			Database: "yy",
+			State:    "idle",
+		},
+	}
 	return st
 }
 
@@ -144,6 +206,8 @@ func TestResponseContainsMetrics(t *testing.T) {
 				ExportDatabases: testCase.exportDatabases,
 				ExportStats:     testCase.exportStats,
 				ExportLists:     testCase.exportLists,
+				ExportServers:   testCase.exportServers,
+				ExportClients:   testCase.exportClients,
 			}
 
 			st := newTestingStore()
@@ -171,6 +235,12 @@ func TestResponseContainsMetrics(t *testing.T) {
 			}
 			if cfg.ExportLists {
 				assert.True(t, st.ListsCalled)
+			}
+			if cfg.ExportServers {
+				assert.True(t, st.ServersCalled)
+			}
+			if cfg.ExportClients {
+				assert.True(t, st.ClientsCalled)
 			}
 
 			for _, expMetric := range testCase.metrics {

--- a/internal/store/mock.go
+++ b/internal/store/mock.go
@@ -17,11 +17,15 @@ type MockStore struct {
 	Pools     []domain.Pool
 	Databases []domain.Database
 	Lists     []domain.List
+	Servers   []domain.Server
+	Clients   []domain.Client
 
 	StatsCalled     bool
 	PoolsCalled     bool
 	DatabasesCalled bool
 	ListsCalled     bool
+	ServersCalled   bool
+	ClientsCalled   bool
 	CloseCalled     bool
 	CheckCalled     bool
 }
@@ -48,6 +52,18 @@ func (s *MockStore) GetDatabases(ctx context.Context) ([]domain.Database, error)
 func (s *MockStore) GetLists(ctx context.Context) ([]domain.List, error) {
 	s.ListsCalled = true
 	return s.Lists, nil
+}
+
+// GetServers returns servers.
+func (s *MockStore) GetServers(ctx context.Context) ([]domain.Server, error) {
+	s.ServersCalled = true
+	return s.Servers, nil
+}
+
+// GetClients returns clients.
+func (s *MockStore) GetClients(ctx context.Context) ([]domain.Client, error) {
+	s.ClientsCalled = true
+	return s.Clients, nil
 }
 
 // Check checks the health of the store.

--- a/internal/store/sql.go
+++ b/internal/store/sql.go
@@ -65,6 +65,46 @@ type list struct {
 	Items int64  `db:"items"`
 }
 
+type server struct {
+	Type        string `db:"type"`
+	User        string `db:"user"`
+	Database    string `db:"database"`
+	State       string `db:"state"`
+	Addr        string `db:"addr"`
+	Port        int64  `db:"port"`
+	LocalAddr   string `db:"local_addr"`
+	LocalPort   int64  `db:"local_port"`
+	ConnectTime string `db:"connect_time"`
+	RequestTime string `db:"request_time"`
+	Wait        int64  `db:"wait"`
+	WaitUs      int64  `db:"wait_us"`
+	CloseNeeded int64  `db:"close_needed"`
+	Ptr         string `db:"ptr"`
+	Link        string `db:"link"`
+	RemotePid   string `db:"remote_pid"`
+	Tls         string `db:"tls"`
+}
+
+type client struct {
+	Type        string `db:"type"`
+	User        string `db:"user"`
+	Database    string `db:"database"`
+	State       string `db:"state"`
+	Addr        string `db:"addr"`
+	Port        int64  `db:"port"`
+	LocalAddr   string `db:"local_addr"`
+	LocalPort   int64  `db:"local_port"`
+	ConnectTime string `db:"connect_time"`
+	RequestTime string `db:"request_time"`
+	Wait        int64  `db:"wait"`
+	WaitUs      int64  `db:"wait_us"`
+	CloseNeeded int64  `db:"close_needed"`
+	Ptr         string `db:"ptr"`
+	Link        string `db:"link"`
+	RemotePid   string `db:"remote_pid"`
+	Tls         string `db:"tls"`
+}
+
 // NewSQL returns a new SQLStore.
 func NewSQL(dataSource string) (*SQLStore, error) {
 	db, err := sqlx.Open("postgres", dataSource)
@@ -153,6 +193,40 @@ func (s *SQLStore) GetLists(ctx context.Context) ([]domain.List, error) {
 	var result []domain.List
 	for _, row := range lists {
 		result = append(result, domain.List(row))
+	}
+	return result, nil
+}
+
+// GetServers returns servers.
+func (s *SQLStore) GetServers(ctx context.Context) ([]domain.Server, error) {
+	var servers []server
+	if err := s.db.SelectContext(ctx, &servers, "SHOW SERVERS"); err != nil {
+		return nil, err
+	}
+	var result []domain.Server
+	for _, row := range servers {
+		result = append(result, domain.Server{
+			User:     row.User,
+			Database: row.Database,
+			State:    row.State,
+		})
+	}
+	return result, nil
+}
+
+// GetClients returns servers.
+func (s *SQLStore) GetClients(ctx context.Context) ([]domain.Client, error) {
+	var clients []client
+	if err := s.db.SelectContext(ctx, &clients, "SHOW CLIENTS"); err != nil {
+		return nil, err
+	}
+	var result []domain.Client
+	for _, row := range clients {
+		result = append(result, domain.Client{
+			User:     row.User,
+			Database: row.Database,
+			State:    row.State,
+		})
 	}
 	return result, nil
 }

--- a/main.go
+++ b/main.go
@@ -59,6 +59,18 @@ func main() {
 				EnvVars: []string{"EXPORT_LISTS"},
 				Value:   true,
 			},
+			&cli.BoolFlag{
+				Name:    "export-servers",
+				Usage:   "Export servers.",
+				EnvVars: []string{"EXPORT_SERVERS"},
+				Value:   true,
+			},
+			&cli.BoolFlag{
+				Name:    "export-clients",
+				Usage:   "Export clients.",
+				EnvVars: []string{"EXPORT_CLIENTS"},
+				Value:   true,
+			},
 			&cli.DurationFlag{
 				Name:    "store-timeout",
 				Usage:   "Per method store timeout.",


### PR DESCRIPTION
https://github.com/jbub/pgbouncer_exporter/issues/6
https://github.com/jbub/pgbouncer_exporter/issues/7

This is not super useful as-is since all of these metrics should technically be available through the `SHOW POOLS` as well, but it at least lays the groundwork for additions.