### PR TITLE
Support pgbouncer 1.18+

### DIFF
--- a/internal/collector/metrics.go
+++ b/internal/collector/metrics.go
@@ -10,22 +10,6 @@ func buildMetrics(cfg config.Config) []metric {
 	return []metric{
 		{
 			enabled: cfg.ExportStats,
-			name:    fqName(SubsystemStats, "total_requests"),
-			help:    "Total number of SQL requests pooled by pgbouncer.",
-			labels:  []string{"database"},
-			valType: prometheus.GaugeValue,
-			eval: func(res *storeResult) (results []metricResult) {
-				for _, stat := range res.stats {
-					results = append(results, metricResult{
-						labels: []string{stat.Database},
-						value:  float64(stat.TotalRequests),
-					})
-				}
-				return results
-			},
-		},
-		{
-			enabled: cfg.ExportStats,
 			name:    fqName(SubsystemStats, "total_received"),
 			help:    "Total volume in bytes of network traffic received by pgbouncer.",
 			labels:  []string{"database"},

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -29,6 +29,7 @@ type Pool struct {
 	User                string
 	Active              int64
 	Waiting             int64
+	CancelReq           int64
 	ActiveCancelReq     int64
 	WaitingCancelReq    int64
 	ServerActive        int64

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -14,10 +14,8 @@ type Stat struct {
 	TotalXactTime     int64
 	TotalQueryCount   int64
 	TotalWaitTime     int64
-	AverageRequests   int64
 	AverageReceived   int64
 	AverageSent       int64
-	AverageQuery      int64
 	AverageQueryCount int64
 	AverageQueryTime  int64
 	AverageXactTime   int64

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -25,19 +25,22 @@ type Stat struct {
 
 // Pool represents pool row.
 type Pool struct {
-	Database     string
-	User         string
-	Active       int64
-	Waiting      int64
-	CancelReq    int64
-	ServerActive int64
-	ServerIdle   int64
-	ServerUsed   int64
-	ServerTested int64
-	ServerLogin  int64
-	MaxWait      int64
-	MaxWaitUs    int64
-	PoolMode     string
+	Database            string
+	User                string
+	Active              int64
+	Waiting             int64
+	ActiveCancelReq     int64
+	WaitingCancelReq    int64
+	ServerActive        int64
+	ServerActiveCancel  int64
+	ServerBeingCanceled int64
+	ServerIdle          int64
+	ServerUsed          int64
+	ServerTested        int64
+	ServerLogin         int64
+	MaxWait             int64
+	MaxWaitUs           int64
+	PoolMode            string
 }
 
 // Database represents database row.

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -7,7 +7,6 @@ import (
 // Stat represents stat row.
 type Stat struct {
 	Database          string
-	TotalRequests     int64
 	TotalReceived     int64
 	TotalSent         int64
 	TotalQueryTime    int64

--- a/internal/server/http_test.go
+++ b/internal/server/http_test.go
@@ -34,7 +34,6 @@ var (
 			exportStats: true,
 			metrics: []string{
 				buildInfoMetric,
-				metricName(collector.SubsystemStats, "total_requests"),
 				metricName(collector.SubsystemStats, "total_received"),
 				metricName(collector.SubsystemStats, "total_sent"),
 				metricName(collector.SubsystemStats, "total_query_time"),

--- a/internal/sqlstore/sql.go
+++ b/internal/sqlstore/sql.go
@@ -73,32 +73,32 @@ func (s *Store) GetStats(ctx context.Context) ([]domain.Stat, error) {
 			switch column {
 			case "database":
 				dest = append(dest, &row.Database)
+			case "total_xact_count":
+				dest = append(dest, &row.TotalXactCount)
+			case "total_query_count":
+				dest = append(dest, &row.TotalQueryCount)
 			case "total_received":
 				dest = append(dest, &row.TotalReceived)
 			case "total_sent":
 				dest = append(dest, &row.TotalSent)
-			case "total_query_time":
-				dest = append(dest, &row.TotalQueryTime)
-			case "total_xact_count":
-				dest = append(dest, &row.TotalXactCount)
 			case "total_xact_time":
 				dest = append(dest, &row.TotalXactTime)
-			case "total_query_count":
-				dest = append(dest, &row.TotalQueryCount)
+			case "total_query_time":
+				dest = append(dest, &row.TotalQueryTime)
 			case "total_wait_time":
 				dest = append(dest, &row.TotalWaitTime)
+			case "avg_xact_count":
+				dest = append(dest, &row.AverageXactCount)
+			case "avg_query_count":
+				dest = append(dest, &row.AverageQueryCount)
 			case "avg_recv":
 				dest = append(dest, &row.AverageReceived)
 			case "avg_sent":
 				dest = append(dest, &row.AverageSent)
-			case "avg_query_count":
-				dest = append(dest, &row.AverageQueryCount)
-			case "avg_query_time":
-				dest = append(dest, &row.AverageQueryTime)
 			case "avg_xact_time":
 				dest = append(dest, &row.AverageXactTime)
-			case "avg_xact_count":
-				dest = append(dest, &row.AverageXactCount)
+			case "avg_query_time":
+				dest = append(dest, &row.AverageQueryTime)
 			case "avg_wait_time":
 				dest = append(dest, &row.AverageWaitTime)
 			default:

--- a/internal/sqlstore/sql.go
+++ b/internal/sqlstore/sql.go
@@ -9,19 +9,22 @@ import (
 )
 
 type pool struct {
-	Database     string
-	User         string
-	Active       int64
-	Waiting      int64
-	CancelReq    int64
-	ServerActive int64
-	ServerIdle   int64
-	ServerUsed   int64
-	ServerTested int64
-	ServerLogin  int64
-	MaxWait      int64
-	MaxWaitUs    int64
-	PoolMode     sql.NullString
+	Database            string
+	User                string
+	Active              int64
+	Waiting             int64
+	ActiveCancelReq     int64
+	WaitingCancelReq    int64
+	ServerActive        int64
+	ServerActiveCancel  int64
+	ServerBeingCanceled int64
+	ServerIdle          int64
+	ServerUsed          int64
+	ServerTested        int64
+	ServerLogin         int64
+	MaxWait             int64
+	MaxWaitUs           int64
+	PoolMode            sql.NullString
 }
 
 type database struct {
@@ -148,10 +151,16 @@ func (s *Store) GetPools(ctx context.Context) ([]domain.Pool, error) {
 				dest = append(dest, &row.Active)
 			case "cl_waiting":
 				dest = append(dest, &row.Waiting)
-			case "cl_cancel_req":
-				dest = append(dest, &row.CancelReq)
+			case "cl_active_cancel_req":
+				dest = append(dest, &row.ActiveCancelReq)
+			case "cl_waiting_cancel_req":
+				dest = append(dest, &row.WaitingCancelReq)
 			case "sv_active":
 				dest = append(dest, &row.ServerActive)
+			case "sv_active_cancel":
+				dest = append(dest, &row.ServerActiveCancel)
+			case "sv_being_canceled":
+				dest = append(dest, &row.ServerBeingCanceled)
 			case "sv_idle":
 				dest = append(dest, &row.ServerIdle)
 			case "sv_used":

--- a/internal/sqlstore/sql.go
+++ b/internal/sqlstore/sql.go
@@ -13,6 +13,7 @@ type pool struct {
 	User                string
 	Active              int64
 	Waiting             int64
+	CancelReq           int64
 	ActiveCancelReq     int64
 	WaitingCancelReq    int64
 	ServerActive        int64
@@ -151,6 +152,8 @@ func (s *Store) GetPools(ctx context.Context) ([]domain.Pool, error) {
 				dest = append(dest, &row.Active)
 			case "cl_waiting":
 				dest = append(dest, &row.Waiting)
+			case "cl_cancel_req":
+				dest = append(dest, &row.CancelReq)
 			case "cl_active_cancel_req":
 				dest = append(dest, &row.ActiveCancelReq)
 			case "cl_waiting_cancel_req":

--- a/internal/sqlstore/sql.go
+++ b/internal/sqlstore/sql.go
@@ -73,8 +73,6 @@ func (s *Store) GetStats(ctx context.Context) ([]domain.Stat, error) {
 			switch column {
 			case "database":
 				dest = append(dest, &row.Database)
-			case "total_requests":
-				dest = append(dest, &row.TotalRequests)
 			case "total_received":
 				dest = append(dest, &row.TotalReceived)
 			case "total_sent":

--- a/internal/sqlstore/sql.go
+++ b/internal/sqlstore/sql.go
@@ -87,14 +87,10 @@ func (s *Store) GetStats(ctx context.Context) ([]domain.Stat, error) {
 				dest = append(dest, &row.TotalQueryCount)
 			case "total_wait_time":
 				dest = append(dest, &row.TotalWaitTime)
-			case "avg_req":
-				dest = append(dest, &row.AverageRequests)
 			case "avg_recv":
 				dest = append(dest, &row.AverageReceived)
 			case "avg_sent":
 				dest = append(dest, &row.AverageSent)
-			case "avg_query":
-				dest = append(dest, &row.AverageQuery)
 			case "avg_query_count":
 				dest = append(dest, &row.AverageQueryCount)
 			case "avg_query_time":

--- a/internal/sqlstore/sql_test.go
+++ b/internal/sqlstore/sql_test.go
@@ -47,7 +47,6 @@ func TestGetStats(t *testing.T) {
 
 	stat := stats[0]
 	require.Equal(t, data["database"].(string), stat.Database)
-	require.Equal(t, int64(data["total_requests"].(int)), stat.TotalRequests)
 	require.Equal(t, int64(data["total_received"].(int)), stat.TotalReceived)
 	require.Equal(t, int64(data["total_sent"].(int)), stat.TotalSent)
 	require.Equal(t, int64(data["total_query_time"].(int)), stat.TotalQueryTime)

--- a/internal/sqlstore/sql_test.go
+++ b/internal/sqlstore/sql_test.go
@@ -20,19 +20,19 @@ func TestGetStats(t *testing.T) {
 
 	data := map[string]interface{}{
 		"database":          "pgbouncer",
-		"total_received":    1,
-		"total_sent":        2,
-		"total_query_time":  3,
-		"total_xact_count":  4,
+		"total_xact_count":  1,
+		"total_query_count": 2,
+		"total_received":    3,
+		"total_sent":        4,
 		"total_xact_time":   5,
-		"total_query_count": 6,
+		"total_query_time":  6,
 		"total_wait_time":   7,
-		"avg_recv":          8,
-		"avg_sent":          9,
-		"avg_query_count":   10,
-		"avg_query_time":    11,
+		"avg_xact_count":    8,
+		"avg_query_count":   9,
+		"avg_recv":          10,
+		"avg_sent":          11,
 		"avg_xact_time":     12,
-		"avg_xact_count":    13,
+		"avg_query_time":    13,
 		"avg_wait_time":     14,
 	}
 
@@ -44,19 +44,19 @@ func TestGetStats(t *testing.T) {
 
 	stat := stats[0]
 	require.Equal(t, data["database"].(string), stat.Database)
+	require.Equal(t, int64(data["total_xact_count"].(int)), stat.TotalXactCount)
+	require.Equal(t, int64(data["total_query_count"].(int)), stat.TotalQueryCount)
 	require.Equal(t, int64(data["total_received"].(int)), stat.TotalReceived)
 	require.Equal(t, int64(data["total_sent"].(int)), stat.TotalSent)
-	require.Equal(t, int64(data["total_query_time"].(int)), stat.TotalQueryTime)
-	require.Equal(t, int64(data["total_xact_count"].(int)), stat.TotalXactCount)
 	require.Equal(t, int64(data["total_xact_time"].(int)), stat.TotalXactTime)
-	require.Equal(t, int64(data["total_query_count"].(int)), stat.TotalQueryCount)
+	require.Equal(t, int64(data["total_query_time"].(int)), stat.TotalQueryTime)
 	require.Equal(t, int64(data["total_wait_time"].(int)), stat.TotalWaitTime)
+	require.Equal(t, int64(data["avg_xact_count"].(int)), stat.AverageXactCount)
+	require.Equal(t, int64(data["avg_query_count"].(int)), stat.AverageQueryCount)
 	require.Equal(t, int64(data["avg_recv"].(int)), stat.AverageReceived)
 	require.Equal(t, int64(data["avg_sent"].(int)), stat.AverageSent)
-	require.Equal(t, int64(data["avg_query_count"].(int)), stat.AverageQueryCount)
-	require.Equal(t, int64(data["avg_query_time"].(int)), stat.AverageQueryTime)
 	require.Equal(t, int64(data["avg_xact_time"].(int)), stat.AverageXactTime)
-	require.Equal(t, int64(data["avg_xact_count"].(int)), stat.AverageXactCount)
+	require.Equal(t, int64(data["avg_query_time"].(int)), stat.AverageQueryTime)
 	require.Equal(t, int64(data["avg_wait_time"].(int)), stat.AverageWaitTime)
 }
 

--- a/internal/sqlstore/sql_test.go
+++ b/internal/sqlstore/sql_test.go
@@ -20,23 +20,20 @@ func TestGetStats(t *testing.T) {
 
 	data := map[string]interface{}{
 		"database":          "pgbouncer",
-		"total_requests":    1,
-		"total_received":    2,
-		"total_sent":        3,
-		"total_query_time":  4,
-		"total_xact_count":  5,
-		"total_xact_time":   6,
-		"total_query_count": 7,
-		"total_wait_time":   8,
-		"avg_req":           9,
-		"avg_recv":          10,
-		"avg_sent":          11,
-		"avg_query":         12,
-		"avg_query_count":   13,
-		"avg_query_time":    14,
-		"avg_xact_time":     15,
-		"avg_xact_count":    16,
-		"avg_wait_time":     17,
+		"total_received":    1,
+		"total_sent":        2,
+		"total_query_time":  3,
+		"total_xact_count":  4,
+		"total_xact_time":   5,
+		"total_query_count": 6,
+		"total_wait_time":   7,
+		"avg_recv":          8,
+		"avg_sent":          9,
+		"avg_query_count":   10,
+		"avg_query_time":    11,
+		"avg_xact_time":     12,
+		"avg_xact_count":    13,
+		"avg_wait_time":     14,
 	}
 
 	mock.ExpectQuery("SHOW STATS").WillReturnRows(mapToRows(data))
@@ -54,10 +51,8 @@ func TestGetStats(t *testing.T) {
 	require.Equal(t, int64(data["total_xact_time"].(int)), stat.TotalXactTime)
 	require.Equal(t, int64(data["total_query_count"].(int)), stat.TotalQueryCount)
 	require.Equal(t, int64(data["total_wait_time"].(int)), stat.TotalWaitTime)
-	require.Equal(t, int64(data["avg_req"].(int)), stat.AverageRequests)
 	require.Equal(t, int64(data["avg_recv"].(int)), stat.AverageReceived)
 	require.Equal(t, int64(data["avg_sent"].(int)), stat.AverageSent)
-	require.Equal(t, int64(data["avg_query"].(int)), stat.AverageQuery)
 	require.Equal(t, int64(data["avg_query_count"].(int)), stat.AverageQueryCount)
 	require.Equal(t, int64(data["avg_query_time"].(int)), stat.AverageQueryTime)
 	require.Equal(t, int64(data["avg_xact_time"].(int)), stat.AverageXactTime)


### PR DESCRIPTION
- Basicaly tested with pgbouncer 1.15-1.20 (docker compose)
- `cl_cancel_req` left for backward compatibility, should be removed in future probably
- Reordered stats fields like in pgbouncer table



- Close https://github.com/jbub/pgbouncer_exporter/issues/5
- Close https://github.com/jbub/pgbouncer_exporter/issues/23

